### PR TITLE
[AMP-2837] Added the word required instead of asterisk

### DIFF
--- a/src/components/api-request.js
+++ b/src/components/api-request.js
@@ -401,15 +401,17 @@ export default class ApiRequest extends LitElement {
       <tr title="${param.deprecated ? 'Deprecated' : ''}"> 
         <td rowspan="${this.allowTry === 'true' ? '1' : '2'}" style="width:${labelColWidth}; min-width:100px;">
           <div class="param-name ${param.deprecated ? 'deprecated' : ''}" >
-            ${param.deprecated ? html`<span style='color:var(--red);'>✗</span>` : ''}
-            ${param.required ? html`<span style='color:var(--red)'>*</span>` : ''}
+            ${param.deprecated ? html`<span style='color:var(--red);'>✗</span>` : ''}            
             ${param.name}
           </div>
           <div class="param-type">
             ${paramSchema.type === 'array'
               ? `${paramSchema.arrayType}`
               : `${paramSchema.format ? paramSchema.format : paramSchema.type}`
-            }
+            }            
+          </div>
+          <div class="param-name" >
+          ${param.required ? html`<span style="color:var(--red)">required</span>` : ''}
           </div>
         </td>  
         ${this.allowTry === 'true'

--- a/src/components/api-request.js
+++ b/src/components/api-request.js
@@ -773,7 +773,7 @@ export default class ApiRequest extends LitElement {
     return html`
       <div class='request-body-container' data-selected-request-body-type="${this.selectedRequestBodyType}">
         <div class="table-title top-gap row">
-          REQUEST BODY ${this.request_body.required ? html`<span class="mono-font" style='color:var(--red)'>*</span>` : ''} 
+          REQUEST BODY
           <span style = "font-weight:normal; margin-left:5px"> ${this.selectedRequestBodyType}</span>
           <span style="flex:1"></span>
           ${reqBodyTypeSelectorHtml}

--- a/src/components/schema-tree.js
+++ b/src/components/schema-tree.js
@@ -109,7 +109,7 @@ export default class SchemaTree extends LitElement {
         </div>
         <span part="schema-description" class='m-markdown'> ${unsafeHTML(marked(this.data?.['::description'] || ''))}</span>
         ${this.data
-          ? html`<span style='color:var(--red);'>*<span style='font-size:11px'> Required</span></span></br>
+            ? html`
             ${this.generateTree(
               this.data['::type'] === 'array' ? this.data['::props'] : this.data,
               this.data['::type'],
@@ -221,11 +221,11 @@ export default class SchemaTree extends LitElement {
                 : schemaLevel > 0
                   ? html`<span class="key-label" title="${readOrWrite === 'readonly' ? 'Read-Only' : readOrWrite === 'writeonly' ? 'Write-Only' : ''}">
                       ${data['::deprecated'] ? '✗' : ''}
-                      ${keyLabel.replace(/\*$/, '')}${keyLabel.endsWith('*') ? html`<span style="color:var(--red)">*</span>` : ''}${readOrWrite === 'readonly' ? html` 🆁` : readOrWrite === 'writeonly' ? html` 🆆` : readOrWrite}:
+                      ${keyLabel.replace(/\*$/, '')}${readOrWrite === 'readonly' ? html` 🆁` : readOrWrite === 'writeonly' ? html` 🆆` : readOrWrite}:
                     </span>`
                   : ''
             }
-            ${openBracket}
+            ${openBracket} ${keyLabel.endsWith('*') ? html`<br/><span style='color:var(--red);line-height:2.5;'>required</span>` : ''}
           </div>
           <div class='td key-descr m-markdown-small'>${unsafeHTML(marked(description || ''))}</div>
         </div>
@@ -303,14 +303,15 @@ export default class SchemaTree extends LitElement {
         <div class="td key ${deprecated}" style='min-width:${minFieldColWidth}px'>
           ${deprecated ? html`<span style='color:var(--red);'>✗</span>` : ''}
           ${keyLabel.endsWith('*')
-            ? html`<span class="key-label">${keyLabel.substring(0, keyLabel.length - 1)}</span><span style='color:var(--red);'>*</span>:`
+            ? html`<span class="key-label">${keyLabel.substring(0, keyLabel.length - 1)}</span>:`
             : key.startsWith('::OPTION')
               ? html`<span class='key-label xxx-of-key'>${keyLabel}</span><span class="xxx-of-descr">${keyDescr}</span>`
               : html`<span class="key-label">${keyLabel}:</span>`
           }
           <span class="${dataTypeCss}" title="${finalReadWriteTip}"> 
             ${dataType === 'array' ? `[${type}]` : `${type}`}
-            ${finalReadWriteText}
+            ${finalReadWriteText}           
+            ${keyLabel.endsWith('*') ? html`<br/><span style='color:var(--red);line-height:2.5;'> required</span></div>` : ''}
           </span>
         </div>
         <div class='td key-descr'>


### PR DESCRIPTION
In the API specification document, indication of mandatory fields has been changed from red asterisk(*) to the wording - 'required' (added the word).

1. The word 'required' has been added in red font in all the individual mandatory field instead of '*' in red font.
2. The word 'required' has been added in red font in all the Request Path parameters, request and response headers section instead of '*' in red font.(please see the attachment)


![image](https://github.com/NHS-digital-website/hippo/assets/164230338/0b300f5d-224f-4b6d-97f7-0348caba9200)
![image](https://github.com/NHS-digital-website/hippo/assets/164230338/3264df12-6838-4340-9ec9-75b24e9d9b40)
![image](https://github.com/NHS-digital-website/hippo-RapiDoc/assets/164230338/fdbb015a-318b-44ba-aae0-85e695097347)

