### PR TITLE
[AMP-3153] Fixed header height adjustment fix

### DIFF
--- a/src/styles/custom-styles.js
+++ b/src/styles/custom-styles.js
@@ -601,4 +601,12 @@ export default css`
   .nhsd-m-table__mobile-list {
     margin-top: 15px;
   }
+
+    h2::before {
+        content: "";
+        display: block;
+        height: 100px; /* Adjust based on your fixed header's height */
+        margin-top: -100px; /* Same value as the height */
+        visibility: hidden;
+    }
 `;


### PR DESCRIPTION
In API specification page, made the changes to display the section header('Supplier Statuses' in the below example) in top of the main body when user clicks its section links from another section main body.  

It was not worked for the rapidoc generated api specs, it is fixed in the story in rapidoc css.

Before Fix:
![image](https://github.com/user-attachments/assets/c11ab2b0-087d-4fb9-9991-55deb53338f9)

After Fix:
![image](https://github.com/user-attachments/assets/e5d26a63-adb6-4165-9884-613005b8df66)
