### PR TITLE
[AMP-3334] Copy Button overlay fix

### DIFF
--- a/src/components/api-request.js
+++ b/src/components/api-request.js
@@ -1016,8 +1016,8 @@ export default class ApiRequest extends LitElement {
   curlSyntaxTemplate(display = 'flex') {
     return html`
       <div class="col m-markdown" style="flex:1; display:${display}; position:relative; max-width: 100%;">
-        <button  class="toolbar-btn" style = "position:absolute; top:12px; right:8px" @click='${(e) => { copyToClipboard(this.curlSyntax.replace(/\\$/, ''), e); }}' part="btn btn-fill"> Copy </button>
-        <pre style="white-space:pre"><code>${unsafeHTML(Prism.highlight(this.curlSyntax.trim().replace(/\\$/, ''), Prism.languages.shell, 'shell'))}</code></pre>
+        <button  class="toolbar-btn" style = "position:absolute; top:12px; right:8px; z-index:10;" @click='${(e) => { copyToClipboard(this.curlSyntax.replace(/\\$/, ''), e); }}' part="btn btn-fill"> Copy </button>
+        <pre style="white-space:pre; padding-top: 60px;"><code>${unsafeHTML(Prism.highlight(this.curlSyntax.trim().replace(/\\$/, ''), Prism.languages.shell, 'shell'))}</code></pre>
       </div>
       `;
   }

--- a/src/components/json-tree.js
+++ b/src/components/json-tree.js
@@ -96,8 +96,8 @@ export default class JsonTree extends LitElement {
   /* eslint-disable indent */
   render() {
     return html`
-      <div class = "scrollable-container">
-        <div class = "json-tree"  @click='${(e) => { if (e.target.classList.contains('btn-copy')) { copyToClipboard(JSON.stringify(this.data, null, 2), e); } else { this.toggleExpand(e); } }}'>
+      <div class = "json-tree"  @click='${(e) => { if (e.target.classList.contains('btn-copy')) { copyToClipboard(JSON.stringify(this.data, null, 2), e); } else { this.toggleExpand(e); } }}' style="position: relative; padding-top: 40px;">
+        <div class = "scrollable-container">
           <div class='toolbar'>
             <button class="toolbar-btn btn-copy" part="btn btn-fill btn-copy"> Copy </button>
           </div>


### PR DESCRIPTION

Copy button in production API Spec page:
![image](https://github.com/user-attachments/assets/97b32cf0-f580-4176-ad08-63aa8e7a2141)

Copy button position fix in API spec page:(After Fix)
![image](https://github.com/user-attachments/assets/1ea0e899-a54c-48b6-958e-623d50a5ea59)

The copy button has been positioned in top right and now the content remains fully visible and is not overlapped or hidden. 